### PR TITLE
Use dev_dependencies in favour of dependencies for unittest

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,6 @@ author: Joris Hermans <hermansj@gmail.com>
 description: A serverside mvc framework
 homepage: https://github.com/jorishermans/dart-forcemvc
 dependencies:
-  unittest: '>=0.9.0 <0.9.1'
   http: '>=0.9.0 <0.10.0'
   http_server: '>=0.9.0 <0.10.0'
   logging: '>=0.9.0 <0.10.0'
@@ -12,3 +11,5 @@ dependencies:
   uuid: '0.2.2'
   mustache: '>=0.1.0 <0.2.0'
   forcemirrors: '0.1.6+1'
+dev_dependencies:
+  unittest: '>=0.9.0 <0.9.1'


### PR DESCRIPTION
This way I can get rid of this message on running `pub get`

```

--- Feb 24, 2014 6:03:41 PM Running pub get ... ---
Pub get failed, [1] Resolving dependencies.................
Incompatible version constraints on unittest:
- forcemvc depends on version >=0.9.0 <0.9.1
- lexer depends on version 0.10.0
- myapp depends on version any


```

Because when myapp depends on lexer, Pub will not include the unittest version 0.10.0 anymore.
