### PR TITLE
Added CORS to Making Cross-Domain Requests

### DIFF
--- a/lib/server/web_server.dart
+++ b/lib/server/web_server.dart
@@ -2,40 +2,41 @@ part of dart_force_mvc_lib;
 
 class WebServer extends SimpleWebServer with ServingFiles {
   final Logger log = new Logger('WebServer');
-  
+	bool Cors=false;
   Router router;
   ForceViewRender viewRender;
   ForceRegistry registry;
-  
+
   SecurityContextHolder securityContext;
   InterceptorsCollection interceptors = new InterceptorsCollection();
-  
-  WebServer({host: "127.0.0.1",         
+
+  WebServer({host: "127.0.0.1",
              port: 8080,
              wsPath: '/ws',
              clientFiles: '../build/web/',
              clientServe: true,
              views: "../views/",
-             startPage: "index.html"}) : 
-               super(host, port, wsPath, 
+             startPage: "index.html",cors:true}) :
+               super(host, port, wsPath,
                      clientFiles, clientServe) {
     this.startPage = startPage;
     viewRender = new MustacheRender(views, clientFiles, clientServe);
     registry = new ForceRegistry(this);
     securityContext = new SecurityContextHolder(new NoSecurityStrategy());
     _scanning();
+    this.Cors=cors;
   }
-  
+
   void _scanning() {
     this.registry.scanning();
-    
+
     // Search for interceptors
     ClassSearcher<HandlerInterceptor> searcher = new ClassSearcher<HandlerInterceptor>();
     List<HandlerInterceptor> interceptorList = searcher.scan();
-    
+
     interceptors.addAll(interceptorList);
   }
-  
+
   void on(Pattern url, ControllerHandler controllerHandler, {method: RequestMethod.GET, bool authentication: false}) {
    _completer.future.whenComplete(() {
      this.router.serve(url, method: method).listen((HttpRequest req) {
@@ -46,9 +47,9 @@ class WebServer extends SimpleWebServer with ServingFiles {
          req.response.redirect(location, status: 301);
        }
      });
-   }); 
+   });
   }
-  
+
   bool checkSecurity(HttpRequest req, auth) {
     if (auth) {
       return securityContext.checkAuthorization(req);
@@ -56,17 +57,17 @@ class WebServer extends SimpleWebServer with ServingFiles {
       return true;
     }
   }
-  
+
   void _resolveRequest(HttpRequest req, ControllerHandler controllerHandler) {
     Model model = new Model();
     ForceRequest forceRequest = new ForceRequest(req);
-    
+
     interceptors.preHandle(forceRequest, model, this);
     var result = controllerHandler(forceRequest, model);
     interceptors.postHandle(forceRequest, model, this);
     if (result != null) {
        // template rendering
-       if (result is String) { 
+       if (result is String) {
          _resolveView(result, req, model);
        } else if (result is Future) {
           Future future = result;
@@ -85,7 +86,7 @@ class WebServer extends SimpleWebServer with ServingFiles {
     }
     interceptors.afterCompletion(forceRequest, model, this);
   }
-  
+
   void _resolveView(String view, HttpRequest req, Model model) {
     if (view.startsWith("redirect:")) {
       Uri location = Uri.parse(view.substring(9));
@@ -94,25 +95,31 @@ class WebServer extends SimpleWebServer with ServingFiles {
       _send_template(req, model, view);
     }
   }
-  
+
   void register(Object obj) {
     this.registry.register(obj);
   }
-  
+
   void _send_template(HttpRequest req, Model model, String view) {
     this.viewRender.render(view, model.getData()).then((String result) {
       _send_response(req.response, new ContentType("text", "html", charset: "utf-8"), result);
     });
   }
-  
+
   void _send_response(HttpResponse response, ContentType contentType, String result) {
-    response
+  	if(this.Cors==true){
+  		response
+        ..headers.add("Access-Control-Allow-Origin", "*, ")
+        ..headers.add("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+        ..headers.add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    }
+  	response
     ..statusCode = 200
     ..headers.contentType = contentType
     ..write(result)
       ..close();
   }
-  
+
   void _onStart(server, [WebSocketHandler handleWs]) {
     log.info("Search server is running on "
         "'http://${Platform.localHostname}:$port/'");
@@ -132,11 +139,11 @@ class WebServer extends SimpleWebServer with ServingFiles {
           }
         });
     }
-    
-    // Serve dart and static files (if not explicitly disabled by clientServe) 
+
+    // Serve dart and static files (if not explicitly disabled by clientServe)
     _serveClient(clientFiles, clientServe);
   }
-  
+
   void set strategy(SecurityStrategy strategy) {
     securityContext.strategy = strategy;
   }


### PR DESCRIPTION
inspired By: https://github.com/chrisbu/dartlang_json_webservice_article_code/blob/master/simpleserver/simpleserver.dart

now you can enable or disable CORS with "cors" bool parameter
WebServer server = new WebServer(... ...  "other parameter" cors:true );

where are used: 

void _send_response(HttpResponse response, ContentType contentType, String result) {
-    response
-      if(this.Cors==true){
-          response
-        ..headers.add("Access-Control-Allow-Origin", "*, ")
-        ..headers.add("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-        ..headers.add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    }
  ... ... ... 
