### PR TITLE
Allow completely handling the HttpResponse

### DIFF
--- a/lib/server/web_application.dart
+++ b/lib/server/web_application.dart
@@ -135,7 +135,7 @@ class WebApplication extends SimpleWebServer with ServingFiles {
           future.then((e) {
             if (e is String) {
               _resolveView(e, req, model);
-            } else if (!(result is HttpResponse)) {
+            } else if (!(e is HttpResponse)) {
               model.addAttributeObject(e);
               _send_json(model.getData(), req);
             }

--- a/lib/server/web_application.dart
+++ b/lib/server/web_application.dart
@@ -135,12 +135,12 @@ class WebApplication extends SimpleWebServer with ServingFiles {
           future.then((e) {
             if (e is String) {
               _resolveView(e, req, model);
-            } else {
+            } else if (!(result is HttpResponse)) {
               model.addAttributeObject(e);
               _send_json(model.getData(), req);
             }
           });
-       } else {
+       } else if (!(result is HttpResponse)) {
          model.addAttributeObject(result);
          _send_json(model.getData(), req);
        }


### PR DESCRIPTION
This adds a mode where the developer can entirely manually handle the HttpResponse. This is activated by returning the HttpResponse on the @RequestMapping function.

Currently it was not possible to directly write to the HttpResponse (`req.request.response`) because the framework was always trying to change headers/write on it.

Alternatively we could detect if the the HttpResponse has already been processed/closed by catching exception when the framework tries to write to the HTTP headers in `_send_response` and, in this case, not write to the body.

PFYI: I need this for a Dart sample I'm writing that will go on the Google Cloud documentation. I'm writing a small JSON API with ForceMVC.